### PR TITLE
Remove caching of all biomes

### DIFF
--- a/src/main/java/eu/pollux28/imggen/gen/biomes/ImgGenBiomeSource.java
+++ b/src/main/java/eu/pollux28/imggen/gen/biomes/ImgGenBiomeSource.java
@@ -74,8 +74,8 @@ public class ImgGenBiomeSource extends BiomeSource {
             sizeX=image.getWidth();
             sizeZ=image.getHeight();
             loadBiomes();
-            generateCache();
-            dumpImage();
+            //generateCache();
+            //dumpImage();
         }
     }
     @Override
@@ -195,7 +195,7 @@ public class ImgGenBiomeSource extends BiomeSource {
             zBase=z<<2;
         }
 
-        return BiomePosCache.getOrDefault(new Vec3i(xBase, 0, zBase), defaultBiome);
+        return getBiomeFromImage(new Vec3i(xBase, 0, zBase));
         /*Set<BiomeCount> biomesAround = new HashSet<>();
 
         for(int iz = -2; iz<= 2; iz++) {
@@ -216,6 +216,24 @@ public class ImgGenBiomeSource extends BiomeSource {
             }
         }
         return biomesAround.parallelStream().max(Comparator.comparingInt((bci) -> bci.count)).get().biome();*/
+    }
+
+    private Biome getBiomeFromImage(Vec3i vec){
+        int x = vec.getX() + sizeX/2;
+        int z = vec.getZ() + sizeZ/2;
+
+        if (x > sizeX - 1 || x < 0 || z > sizeZ - 1 || z < 0){
+            return defaultBiome;
+        }
+
+        int RGB = image.getRGB(x, z)&0xFFFFFF;
+        if(!this.colorsForBiome.containsKey(RGB)){
+            Biome biome = biomesRefColors.int2ObjectEntrySet().stream().sequential().min(Comparator.comparingDouble(
+                    (bt1) -> getColorDiff(RGB, bt1.getIntKey()))).get().getValue();
+            this.colorsForBiome.put(RGB, biome);
+        }
+
+        return this.colorsForBiome.get(RGB);
     }
 
     public BufferedImage setImage(String pathname){


### PR DESCRIPTION
Currently the mod loops over all pixels of the image and stores the location with the associated biome in cache. This does use a lot of RAM and slows down the start of the Client/Server immensely (At least if you're using large images)

This PR removes the cache and loads the biomes from the image as they are needed. From my testing this worked fine while drastically descreasing RAM and boot up time. 

Is there any particular reason why you have decided to cache all biomes?
If so it might be a good idea to have this be something that can be configured in the config file.